### PR TITLE
Add solution for singleNumber problem

### DIFF
--- a/chris/single-number.go
+++ b/chris/single-number.go
@@ -1,0 +1,23 @@
+package chris
+
+func singleNumber(nums []int) int {
+
+	if len(nums) == 1 {
+		return nums[0]
+	}
+
+	result := map[int]int{}
+	for _, v := range nums {
+		if val, ok := result[v]; val == 1 {
+			delete(result, v)
+		} else if !ok {
+			result[v] = 1
+		}
+	}
+
+	for k := range result {
+		return k
+	}
+
+	return nums[0]
+}

--- a/chris/single-number_test.go
+++ b/chris/single-number_test.go
@@ -1,0 +1,35 @@
+package chris
+
+import "testing"
+
+func TestSingleNumber(t *testing.T) {
+
+	type testCase struct {
+		input    []int
+		expected int
+	}
+
+	tests := []testCase{
+		{
+			[]int{2, 2, 1},
+			1,
+		},
+		{
+			[]int{4, 1, 2, 1, 2},
+			4,
+		},
+		{
+			[]int{1},
+			1,
+		},
+	}
+
+	for _, test := range tests {
+		res := singleNumber(test.input)
+
+		if res != test.expected {
+			t.Errorf("singleNumber: expected %d, got %d", test.expected, res)
+		}
+	}
+
+}


### PR DESCRIPTION
There's probably a neater solution than this but it seemed like the easiest way to track which numbers had already been seen:

Runtime: 24 ms, faster than 31.93% of Go online submissions for Single Number.
Memory Usage: 6.3 MB, less than 13.87% of Go online submissions for Single Number.