### PR TITLE
Add chris solution for best time to buy and sell stocks

### DIFF
--- a/chris/best-time-buy-sell.go
+++ b/chris/best-time-buy-sell.go
@@ -1,0 +1,21 @@
+package chris
+
+func maxProfit(prices []int) int {
+
+	profit := 0
+
+	seen := map[int]bool{}
+
+	for i, v := range prices {
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		for j := (len(prices) - 1); j >= (i + 1); j-- {
+			if (prices[j] - v) > profit {
+				profit = prices[j] - v
+			}
+		}
+		seen[v] = true
+	}
+	return profit
+}

--- a/chris/best-time-buy-sell_test.go
+++ b/chris/best-time-buy-sell_test.go
@@ -1,0 +1,34 @@
+package chris
+
+import "testing"
+
+func TestMaxProfit(t *testing.T) {
+
+	type testCase struct {
+		input    []int
+		expected int
+	}
+
+	tests := []testCase{
+		{
+			[]int{7, 1, 5, 3, 6, 4},
+			5,
+		},
+		{
+			[]int{7, 6, 4, 3, 1},
+			0,
+		},
+		{
+			[]int{1, 2},
+			1,
+		},
+	}
+
+	for _, test := range tests {
+		res := maxProfit(test.input)
+
+		if res != test.expected {
+			t.Errorf("maxProfit: expected %d, got %d for input: %v", test.expected, res, test.input)
+		}
+	}
+}


### PR DESCRIPTION
This feels like one that has a trick to solving it quickly but reasonably happy with my solution. First attempt failed as I missed `>=` in my inner for loop, second timed out as I wasn't caching anything and there's a test case with a lot of entries (~66k items) so the double loop was really really slow there.

Runtime: 904 ms, faster than 5.26% of Go online submissions for Best Time to Buy and Sell Stock.
Memory Usage: 8.5 MB, less than 90.06% of Go online submissions for Best Time to Buy and Sell Stock.