### PR TITLE
Add Chris solution for zigzag converstion

### DIFF
--- a/chris/zigzag-conversion.go
+++ b/chris/zigzag-conversion.go
@@ -1,0 +1,53 @@
+package chris
+
+import (
+	"strings"
+)
+
+func convert(s string, numRows int) string {
+
+	if len(s) == 1 || numRows == 1 {
+		return s
+	}
+
+	type grid struct {
+		row int
+		col int
+	}
+
+	zig := make([][]rune, numRows)
+	for i := range zig {
+		zig[i] = make([]rune, (len(s)/2)+1)
+	}
+
+	lastRow := 0
+	cursor := grid{0, 0}
+
+	for _, c := range s {
+		if cursor.col%(numRows-1) == 0 {
+			zig[cursor.row][cursor.col] = c
+			lastRow = cursor.row
+			cursor.row++
+			if cursor.row >= numRows {
+				cursor.col++
+				cursor.row = 0
+			}
+		} else {
+			zig[lastRow-1][cursor.col] = c
+			lastRow--
+			cursor.col++
+			cursor.row = 0
+		}
+	}
+
+	var sb strings.Builder
+	for _, str := range zig {
+		for _, r := range str {
+			if r > 0 {
+				sb.WriteRune(r)
+			}
+		}
+	}
+	res := sb.String()
+	return res
+}

--- a/chris/zigzag-conversion_test.go
+++ b/chris/zigzag-conversion_test.go
@@ -1,0 +1,48 @@
+package chris
+
+import "testing"
+
+func TestConvert(t *testing.T) {
+
+	type testCase struct {
+		inputString string
+		inputNum    int
+		expected    string
+	}
+
+	tests := []testCase{
+		// {
+		// 	"PAYPALISHIRING",
+		// 	3,
+		// 	"PAHNAPLSIIGYIR",
+		// },
+		// {
+		// 	"PAYPALISHIRING",
+		// 	4,
+		// 	"PINALSIGYAHRPI",
+		// },
+		// {
+		// 	"A",
+		// 	1,
+		// 	"A",
+		// },
+		// {
+		// 	"PAYPALISHIRING",
+		// 	1,
+		// 	"PAYPALISHIRING",
+		// },
+		{
+			"ABC",
+			2,
+			"ACB",
+		},
+	}
+
+	for _, test := range tests {
+		res := convert(test.inputString, test.inputNum)
+
+		if res != test.expected {
+			t.Errorf("convert: expected %s, got %s", test.expected, res)
+		}
+	}
+}


### PR DESCRIPTION
Might not be the fanciest solution but seemed like a nicer approach than my initial ideas for brute forcing it somehow. 

Runtime: 24 ms, faster than 10.54% of Go online submissions for ZigZag Conversion.
Memory Usage: 8.1 MB, less than 6.24% of Go online submissions for ZigZag Conversion.